### PR TITLE
Move scene link table operations to repository

### DIFF
--- a/src/components/blockInstance/BlockInstanceEditor/parts/InstanceScenesEditor/InstanceScenesEditor.tsx
+++ b/src/components/blockInstance/BlockInstanceEditor/parts/InstanceScenesEditor/InstanceScenesEditor.tsx
@@ -4,6 +4,7 @@ import { IconLink, IconUnlink, IconArrowRight, IconChevronDown, IconChevronRight
 import { useNavigate } from 'react-router-dom';
 import { IBlockInstanceSceneLink, IScene, IChapter } from '@/entities/BookEntities';
 import { bookDb } from '@/entities/bookDb';
+import { BlockInstanceSceneLinkRepository } from '@/repository/BlockInstance/BlockInstanceSceneLinkRepository';
 import { generateUUID } from '@/utils/UUIDUtils';
 import { useLiveQuery } from 'dexie-react-hooks';
 import {SceneRepository} from "@/repository/Scene/SceneRepository";
@@ -36,7 +37,7 @@ export const InstanceScenesEditor: React.FC<IInstanceScenesEditorProps> = ({ blo
     };
 
     const linkedSceneLinks = useLiveQuery(
-        () => bookDb.blockInstanceSceneLinks.where({ blockInstanceUuid }).toArray(),
+        () => BlockInstanceSceneLinkRepository.getLinksByBlockInstance(bookDb, blockInstanceUuid),
         [blockInstanceUuid],
         undefined
     );
@@ -163,7 +164,7 @@ export const InstanceScenesEditor: React.FC<IInstanceScenesEditorProps> = ({ blo
             sceneId,
         };
         try {
-            await bookDb.blockInstanceSceneLinks.add(newLink);
+            await BlockInstanceSceneLinkRepository.createLink(bookDb, newLink);
         } catch (error) {
             console.error("Failed to link scene:", error);
         }
@@ -177,7 +178,7 @@ export const InstanceScenesEditor: React.FC<IInstanceScenesEditorProps> = ({ blo
             return;
         }
         try {
-            await bookDb.blockInstanceSceneLinks.delete(linkId);
+            await BlockInstanceSceneLinkRepository.deleteLink(bookDb, linkId);
         } catch (error) {
             console.error("Failed to unlink scene:", error);
         }

--- a/src/components/scenes/SceneEditor/parts/SceneLinkManager.tsx
+++ b/src/components/scenes/SceneEditor/parts/SceneLinkManager.tsx
@@ -16,6 +16,7 @@ import {
 import { InlineEdit2 } from "@/components/shared/InlineEdit2/InlineEdit2";
 import { useDisclosure } from "@mantine/hooks";
 import { bookDb } from "@/entities/bookDb";
+import {BlockInstanceSceneLinkRepository} from "@/repository/BlockInstance/BlockInstanceSceneLinkRepository";
 import React, { useEffect, useState } from "react";
 import {IBlockInstance, IBlockInstanceSceneLink} from "@/entities/BookEntities";
 import {IBlock, IBlockStructureKind} from "@/entities/ConstructorEntities";
@@ -39,7 +40,7 @@ export const SceneLinkManager = ({ sceneId, opened, onClose }: SceneLinkManagerP
   }, [sceneId])
 
   const links = useLiveQuery<IBlockInstanceSceneLink[]>(async () => {
-    return bookDb.blockInstanceSceneLinks.where('sceneId').equals(sceneId).toArray();
+    return BlockInstanceSceneLinkRepository.getLinksBySceneId(bookDb, sceneId);
   }, [sceneId])
 
   const blockInstances = useLiveQuery<IBlockInstance[]>(async () => {
@@ -74,18 +75,18 @@ export const SceneLinkManager = ({ sceneId, opened, onClose }: SceneLinkManagerP
       title: newLinkTitle,
     };
 
-    await bookDb.blockInstanceSceneLinks.add(newLink);
+    await BlockInstanceSceneLinkRepository.createLink(bookDb, newLink);
     setNewLinkTitle(''); // Reset title input
     closeModal();
   };
 
   const handleDeleteLink = async (linkId: number) => {
-    await bookDb.blockInstanceSceneLinks.delete(linkId);
+    await BlockInstanceSceneLinkRepository.deleteLink(bookDb, linkId);
   };
 
   const handleUpdateLinkTitle = async (linkId: number, newTitle: string) => {
     try {
-      await bookDb.blockInstanceSceneLinks.update(linkId, { title: newTitle });
+      await BlockInstanceSceneLinkRepository.updateLink(bookDb, linkId, { title: newTitle });
     } catch (error) {
       console.error("Failed to update link title:", error);
     }

--- a/src/components/scenes/SceneLayout/hooks/useSceneLayout.tsx
+++ b/src/components/scenes/SceneLayout/hooks/useSceneLayout.tsx
@@ -6,16 +6,14 @@ import {SceneRepository} from "@/repository/Scene/SceneRepository";
 import {ChapterRepository} from "@/repository/Scene/ChapterRepository";
 import {BlockRepository} from "@/repository/Block/BlockRepository";
 import {BlockInstanceRepository} from "@/repository/BlockInstance/BlockInstanceRepository";
+import {BlockInstanceSceneLinkRepository} from "@/repository/BlockInstance/BlockInstanceSceneLinkRepository";
 
 export const useSceneLayout = () => {
   const scenes = useLiveQuery(() => SceneRepository.getAll(bookDb), [])
   const chapters = useLiveQuery(() => ChapterRepository.getAll(bookDb), [])
 
   const getLinkedBlockInstances = async (sceneId: number) => {
-    const links = await bookDb.blockInstanceSceneLinks
-    .where('sceneId')
-    .equals(sceneId)
-    .toArray();
+    const links = await BlockInstanceSceneLinkRepository.getLinksBySceneId(bookDb, sceneId);
 
     const blockUuids = Array.from(new Set(links.map(l => l.blockUuid)));
     const instanceUuids = links.map(l => l.blockInstanceUuid);

--- a/src/repository/BlockInstance/BlockInstanceRepository.ts
+++ b/src/repository/BlockInstance/BlockInstanceRepository.ts
@@ -5,6 +5,7 @@ import { BlockRepository } from "@/repository/Block/BlockRepository";
 import { BlockParameterInstanceRepository } from "./BlockParameterInstanceRepository";
 import { updateBlockInstance } from "./BlockInstanceUpdateHelper";
 import {BlockInstanceRelationRepository} from "@/repository/BlockInstance/BlockInstanceRelationRepository";
+import {BlockInstanceSceneLinkRepository} from "@/repository/BlockInstance/BlockInstanceSceneLinkRepository";
 
 export const getByUuid = async (db: BookDB, blockInstanceUuid: string) => {
   return db.blockInstances.where('uuid').equals(blockInstanceUuid).first();
@@ -70,7 +71,7 @@ export const remove = async (db: BookDB, instance: IBlockInstance) => {
   await Promise.all([
     BlockInstanceRelationRepository.removeAllForInstance(db, instance.uuid!),
     BlockParameterInstanceRepository.removeAllForInstance(db, instance.uuid!),
-    db.blockInstanceSceneLinks.where('blockInstanceUuid').equals(instance.uuid).delete(),
+    BlockInstanceSceneLinkRepository.removeLinksForInstance(db, instance.uuid!),
     db.blockInstances.delete(instance.id!)
   ]);
 }

--- a/src/repository/BlockInstance/BlockInstanceSceneLinkRepository.ts
+++ b/src/repository/BlockInstance/BlockInstanceSceneLinkRepository.ts
@@ -1,0 +1,76 @@
+import { BookDB } from "@/entities/bookDb";
+import { IBlockInstanceSceneLink } from "@/entities/BookEntities";
+
+export const getLinksBySceneId = async (db: BookDB, sceneId: number) => {
+  return db.blockInstanceSceneLinks
+    .where('sceneId')
+    .equals(sceneId)
+    .toArray();
+};
+
+export const getLinksByBlockInstance = async (
+  db: BookDB,
+  blockInstanceUuid: string
+) => {
+  return db.blockInstanceSceneLinks
+    .where('blockInstanceUuid')
+    .equals(blockInstanceUuid)
+    .toArray();
+};
+
+export const createLink = async (db: BookDB, link: IBlockInstanceSceneLink) => {
+  await db.blockInstanceSceneLinks.add(link);
+};
+
+export const getAllLinks = async (db: BookDB) => {
+  return db.blockInstanceSceneLinks.toArray();
+};
+
+export const updateLink = async (
+  db: BookDB,
+  id: number,
+  changes: Partial<IBlockInstanceSceneLink>
+) => {
+  await db.blockInstanceSceneLinks.update(id, changes);
+};
+
+export const deleteLink = async (db: BookDB, id: number) => {
+  await db.blockInstanceSceneLinks.delete(id);
+};
+
+export const removeLinksForScene = async (db: BookDB, sceneId: number) => {
+  await db.blockInstanceSceneLinks.where('sceneId').equals(sceneId).delete();
+};
+
+export const removeLinksForInstance = async (
+  db: BookDB,
+  blockInstanceUuid: string
+) => {
+  await db.blockInstanceSceneLinks
+    .where('blockInstanceUuid')
+    .equals(blockInstanceUuid)
+    .delete();
+};
+
+export const bulkAddLinks = async (
+  db: BookDB,
+  links: IBlockInstanceSceneLink[]
+) => {
+  if (links.length > 0) {
+    await db.blockInstanceSceneLinks.bulkAdd(links);
+  }
+};
+
+export const BlockInstanceSceneLinkRepository = {
+  getLinksBySceneId,
+  getLinksByBlockInstance,
+  createLink,
+  getAllLinks,
+  updateLink,
+  deleteLink,
+  removeLinksForScene,
+  removeLinksForInstance,
+  bulkAddLinks,
+};
+
+export default BlockInstanceSceneLinkRepository;

--- a/src/repository/Scene/SceneRepository.ts
+++ b/src/repository/Scene/SceneRepository.ts
@@ -1,5 +1,6 @@
 import { BookDB } from "@/entities/bookDb";
 import { IScene } from "@/entities/BookEntities";
+import {BlockInstanceSceneLinkRepository} from "@/repository/BlockInstance/BlockInstanceSceneLinkRepository";
 
 export const getById = async (db: BookDB, sceneId: number): Promise<IScene | undefined> => {
     return db.scenes.get(sceneId);
@@ -67,7 +68,7 @@ export const remove = async (db: BookDB, sceneId: number): Promise<void> => {
     await db.transaction('rw', db.scenes, db.blockInstanceSceneLinks, async () => {
         await db.scenes.delete(sceneId);
         // Also remove related data like links (e.g., blockInstanceSceneLinks)
-        await db.blockInstanceSceneLinks.where('sceneId').equals(sceneId).delete();
+        await BlockInstanceSceneLinkRepository.removeLinksForScene(db, sceneId);
     });
 
     // Recalculate order for the chapter the scene belonged to, or globally if it was chapterless

--- a/src/utils/bookBackupManager.ts
+++ b/src/utils/bookBackupManager.ts
@@ -1,6 +1,7 @@
 import { configDatabase } from "@/entities/configuratorDb";
 import { notifications } from "@mantine/notifications";
 import { connectToBookDatabase, deleteBookDatabase } from "@/entities/bookDb";
+import { BlockInstanceSceneLinkRepository } from "@/repository/BlockInstance/BlockInstanceSceneLinkRepository";
 import { inkLuminAPI } from "@/api/inkLuminApi";
 import moment from "moment";
 
@@ -44,7 +45,7 @@ export const collectBookBackupData = async (bookUuid: string): Promise<BackupDat
     blockParameterPossibleValues: await db.blockParameterPossibleValues.toArray(),
     blocksRelations: await db.blocksRelations.toArray(),
     blockTabs: await db.blockTabs.toArray(),
-    blockInstanceSceneLinks: await db.blockInstanceSceneLinks.toArray(),
+    blockInstanceSceneLinks: await BlockInstanceSceneLinkRepository.getAllLinks(db),
   };
 };
 
@@ -123,7 +124,12 @@ export const importBookData = async (backupData: BackupData): Promise<void> => {
   otherPromises.push(db.blockParameterPossibleValues.bulkAdd(backupData.blockParameterPossibleValues || []));
   otherPromises.push(db.blocksRelations.bulkAdd(backupData.blocksRelations || []));
   otherPromises.push(db.blockTabs.bulkAdd(backupData.blockTabs || []));
-  otherPromises.push(db.blockInstanceSceneLinks.bulkAdd(backupData.blockInstanceSceneLinks || []));
+  otherPromises.push(
+    BlockInstanceSceneLinkRepository.bulkAddLinks(
+      db,
+      backupData.blockInstanceSceneLinks || []
+    )
+  );
 
   if (otherPromises.length > 0) {
     await Promise.all(otherPromises);


### PR DESCRIPTION
## Summary
- introduce `BlockInstanceSceneLinkRepository`
- update `SceneRepository` and `BlockInstanceRepository` to use new repository
- adjust backup manager to fetch and store scene link data via repository
- refactor scene-related components to call repository methods

## Testing
- `npm test` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6850918c0a508320b3fa1d641b847ef4